### PR TITLE
make use of macports optional

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,3 +21,5 @@ upgradepkgs_darwin_santa_temporary_monitor: true
 
 harden_darwin_santa_db_type: string
 # harden_darwin_santa_db_type: int
+
+darwin_use_macports: false

--- a/tasks/darwin.yml
+++ b/tasks/darwin.yml
@@ -44,3 +44,4 @@
 
 - name: Import darwin-macports
   ansible.builtin.import_tasks: darwin-macports.yml
+  when: ( darwin_use_macports is defined and darwin_use_macports)

--- a/tasks/darwin.yml
+++ b/tasks/darwin.yml
@@ -44,4 +44,4 @@
 
 - name: Import darwin-macports
   ansible.builtin.import_tasks: darwin-macports.yml
-  when: ( darwin_use_macports is defined and darwin_use_macports)
+  when: ( darwin_use_macports is defined and darwin_use_macports|bool)


### PR DESCRIPTION
We don't use macports so the upgrade process crashed.