### PR TITLE
Homebrew/bundle not available Update darwin-brew.yml

### DIFF
--- a/tasks/darwin-brew.yml
+++ b/tasks/darwin-brew.yml
@@ -1,10 +1,4 @@
 ---
-
-- name: Install Homebrew/bundle
-  community.general.homebrew:
-    name: Homebrew/bundle
-    state: present
-
 - name: Backup current brew list
   ansible.builtin.command:
     cmd: "brew bundle list --file Brewfile.{{ ansible_date_time.date }}"


### PR DESCRIPTION
brew bundle is installed on first use.
It is not available to install like this.

fatal: [mac]: FAILED! => 
    changed: false
    msg: 'Warning: No available formula with the name "Homebrew/bundle".'